### PR TITLE
refactor: Transition from PyQt6 to PySide6

### DIFF
--- a/app/logic/camera_handler.py
+++ b/app/logic/camera_handler.py
@@ -3,8 +3,8 @@
 import cv2  # Библиотека OpenCV для работы с компьютерным зрением
 import asyncio  # Для асинхронного выполнения операций
 import time # Для отслеживания времени кадра и FPS
-from PyQt6.QtCore import QObject, pyqtSignal, QSize, Qt
-from PyQt6.QtGui import QImage  # Класс для работы с изображениями в PyQt
+from PySide6.QtCore import QObject, Signal, QSize, Qt # PyQt6 -> PySide6, pyqtSignal -> Signal
+from PySide6.QtGui import QImage  # PyQt6 -> PySide6
 
 class CameraHandler(QObject):
     """
@@ -13,9 +13,9 @@ class CameraHandler(QObject):
     Работает в асинхронном режиме, чтобы не блокировать основной поток приложения.
     """
     # Сигнал, передающий новый обработанный кадр (в формате QImage)
-    new_frame = pyqtSignal(QImage)
+    new_frame = Signal(QImage) # pyqtSignal -> Signal
     # Сигнал, сообщающий об ошибках, возникших при работе с камерой
-    camera_error = pyqtSignal(str)
+    camera_error = Signal(str) # pyqtSignal -> Signal
 
     def __init__(self, camera_index=1, capture_width=544, capture_height=288, target_display_size=QSize(400, 300), parent=None):
         """

--- a/app/logic/gpio_controller.py
+++ b/app/logic/gpio_controller.py
@@ -15,7 +15,7 @@
 
 import asyncio
 # import os # Закомментировано/удалено, т.к. os.system был заменен на asyncio.create_subprocess_shell
-from PyQt6.QtCore import QObject, pyqtSignal
+from PySide6.QtCore import QObject, Signal # PyQt6 -> PySide6, pyqtSignal -> Signal
 from gpiozero import Button # Класс для работы с физическими кнопками
 
 class GPIOController(QObject):
@@ -26,7 +26,7 @@ class GPIOController(QObject):
     """
     # Сигнал, эмитируемый после завершения (успешного или неуспешного) действия закрытия браузера.
     # Передает строку с сообщением о результате.
-    shutdown_action_finished = pyqtSignal(str) 
+    shutdown_action_finished = Signal(str) # pyqtSignal -> Signal
 
     def __init__(self, parent=None):
         """

--- a/app/logic/network_checker.py
+++ b/app/logic/network_checker.py
@@ -4,7 +4,7 @@
 # отправляет сигналы для обновления GUI.
 
 import asyncio
-from PyQt6.QtCore import QObject, pyqtSignal
+from PySide6.QtCore import QObject, Signal # PyQt6 -> PySide6, pyqtSignal -> Signal
 from gpiozero import LED, PingServer
 from gpiozero.tools import negated # Утилита для инвертирования значения источника gpiozero
 
@@ -15,7 +15,7 @@ class NetworkChecker(QObject):
     Периодически проверяет статус и отправляет сигнал network_status_gui для обновления UI.
     """
     # Сигнал для обновления GUI: True/False (доступен/нет), строка сообщения
-    network_status_gui = pyqtSignal(bool, str)
+    network_status_gui = Signal(bool, str) # pyqtSignal -> Signal
 
     def __init__(self, parent=None):
         """
@@ -59,7 +59,9 @@ class NetworkChecker(QObject):
         except Exception as e:
             # Обработка возможных исключений при инициализации gpiozero (например, если библиотека не установлена или запущено не на RPi)
             print(f"Ошибка инициализации NetworkChecker (gpiozero): {e}")
-            self.camera_error.emit(f"Ошибка GPIO: {e}") # Используем существующий сигнал для уведомления об ошибке
+            # self.camera_error.emit(f"Ошибка GPIO: {e}") # Удалено, т.к. camera_error не определен здесь.
+            # Вместо этого можно создать свой сигнал ошибки GPIO или использовать logging.
+            # Для данной задачи рефакторинга просто убираем вызов неопределенного сигнала.
             # Устанавливаем заглушки, чтобы приложение не упало при вызове методов
             self.green_led = None
             self.red_led = None

--- a/app/window.py
+++ b/app/window.py
@@ -2,10 +2,10 @@
 # Основной файл для главного окна приложения PyQt.
 # Отвечает за компоновку UI, инициализацию логических модулей и обработку событий.
 
-from PyQt6.QtWidgets import QMainWindow, QWidget, QGridLayout, QLabel, QPushButton, QVBoxLayout
-from PyQt6.QtCore import Qt, QUrl, QTimer, QPoint
-from PyQt6.QtGui import QPixmap # QPalette и QColor удалены, т.к. стилизация через styleSheet
-from PyQt6.QtWebEngineWidgets import QWebEngineView # Для отображения HTML контента (погода)
+from PySide6.QtWidgets import QMainWindow, QWidget, QGridLayout, QLabel, QPushButton, QVBoxLayout # PyQt6 -> PySide6
+from PySide6.QtCore import Qt, QUrl, QTimer, QPoint # PyQt6 -> PySide6
+from PySide6.QtGui import QPixmap # PyQt6 -> PySide6
+from PySide6.QtWebEngineWidgets import QWebEngineView # PyQt6 -> PySide6
 
 # Импорт логических модулей
 from app.logic.camera_handler import CameraHandler

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 # main.py
 import sys
 import asyncio
-import traceback # <--- Добавлено
-from PyQt6.QtWidgets import QApplication, QMessageBox # <--- QMessageBox добавлен
+import traceback
+from PySide6.QtWidgets import QApplication, QMessageBox # PyQt6 -> PySide6
 from app.window import MainWindow 
 import quamash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-PyQt6==6.5.0
+PySide6
 opencv-python==4.8.0.74
 gpiozero==1.6.2
-PyQt6-WebEngine
 quamash


### PR DESCRIPTION
Dependencies and imports throughout the project have been updated to use PySide6 instead of PyQt6.

Key changes:
- In `requirements.txt`, `PyQt6` and `PyQt6-WebEngine` have been replaced with `PySide6`.
- In all Python files within the project (`main.py`, `app/window.py`, `app/logic/*.py`):
    - Imports from `PyQt6.*` have been changed to `PySide6.*` (for QtCore, QtWidgets, QtGui, QtWebEngineWidgets, QtWebEngineCore modules).
    - Signal declarations `pyqtSignal` have been replaced with `Signal` (from `PySide6.QtCore`).
- Compatibility of `Qt.WindowType` flags was checked; no changes were required.

The purpose of these changes is to migrate to the officially supported Qt bindings for Python (PySide6).